### PR TITLE
Wrap header links in nav element

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -5,33 +5,35 @@ export default function Home() {
     <header className="header">
       <h1 className="text-2xl font-semibold text-blue-600">Panja Pavers & Gardening</h1>
 
-      <ul>
-        <li>
-          <Link href="/about" className="underline p-2 m-2">
-            About Us
-          </Link>
-        </li>
-        <li>
-          <Link href="/services" className="underline p-2 m-2">
-            Services
-          </Link>
-        </li>
-        <li>
-          <Link href="/portfolio" className="underline p-2 m-2">
-            Portfolio
-          </Link>
-        </li>
-        <li>
-          <Link href="/testimonials" className="underline p-2 m-2">
-            Testimonials
-          </Link>
-        </li>
-        <li>
-          <Link href="/quote" className="p-2 m-3 bg-cyan-500 hover:bg-cyan-600 rounded-lg transition-all">
-            Get a Quote
-          </Link>
-        </li>
-      </ul>
+      <nav>
+        <ul>
+          <li>
+            <Link href="/about" className="underline p-2 m-2">
+              About Us
+            </Link>
+          </li>
+          <li>
+            <Link href="/services" className="underline p-2 m-2">
+              Services
+            </Link>
+          </li>
+          <li>
+            <Link href="/portfolio" className="underline p-2 m-2">
+              Portfolio
+            </Link>
+          </li>
+          <li>
+            <Link href="/testimonials" className="underline p-2 m-2">
+              Testimonials
+            </Link>
+          </li>
+          <li>
+            <Link href="/quote" className="p-2 m-3 bg-cyan-500 hover:bg-cyan-600 rounded-lg transition-all">
+              Get a Quote
+            </Link>
+          </li>
+        </ul>
+      </nav>
     </header>
   );
 }


### PR DESCRIPTION
## Summary
- wrap header link list in a `<nav>` container for semantic structure

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `npm run build` *(fails: Failed to fetch `Geist` and `Geist Mono` fonts from Google)*

------
https://chatgpt.com/codex/tasks/task_e_68a7ba3070208320bc1f7ddbcd9e48b1