### PR TITLE
chore: use PascalCase for page components

### DIFF
--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -1,6 +1,6 @@
 import Link from "next/link";
 
-export default function about() {
+export default function About() {
     return (
       <div>
         <Link href="/" className="underline p-2 m-2">

--- a/app/portfolio/page.tsx
+++ b/app/portfolio/page.tsx
@@ -1,6 +1,6 @@
 import Link from "next/link";
 
-export default function portfolio() {
+export default function Portfolio() {
   return (
     <div>
       <Link href="/" className="underline p-2 m-2">

--- a/app/quote/page.tsx
+++ b/app/quote/page.tsx
@@ -1,6 +1,6 @@
 import Link from "next/link";
 
-export default function quote() {
+export default function Quote() {
   return (
     <div>
       <Link href="/" className="underline p-2 m-2">
@@ -34,5 +34,5 @@ export default function quote() {
         </ul>
       </form>
     </div>
-  )
+  );
 }

--- a/app/services/page.tsx
+++ b/app/services/page.tsx
@@ -1,6 +1,6 @@
 import Link from "next/link";
 
-export default function services() {
+export default function Services() {
   return (
     <div>
       <Link href="/" className="underline p-2 m-2">

--- a/app/testimonials/page.tsx
+++ b/app/testimonials/page.tsx
@@ -1,6 +1,6 @@
 import Link from "next/link";
 
-export default function testimonials() {
+export default function Testimonials() {
   return (
     <div>
       <Link href="/" className="underline p-2 m-2">


### PR DESCRIPTION
## Summary
- rename page components to PascalCase for consistency

## Testing
- `npm run lint`
- `npm run build` *(fails: Failed to fetch `Geist` from Google Fonts)*

------
https://chatgpt.com/codex/tasks/task_e_68a7ba36c02883209a8e94596c33c56b