### PR TITLE
chore: move types to dev dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,21 +8,21 @@
       "name": "garden-landing-page",
       "version": "0.1.0",
       "dependencies": {
-        "@types/react-dom": "^19.1.7",
         "lucide-react": "^0.540.0",
         "next": "15.5.0",
         "react": "19.1.0",
-        "react-dom": "19.1.0",
-        "typescript": "^5.9.2"
+        "react-dom": "19.1.0"
       },
       "devDependencies": {
         "@eslint/eslintrc": "^3",
         "@tailwindcss/postcss": "^4",
         "@types/node": "^24.3.0",
         "@types/react": "^19.1.10",
+        "@types/react-dom": "^19.1.7",
         "eslint": "^9",
         "eslint-config-next": "15.5.0",
-        "tailwindcss": "^4"
+        "tailwindcss": "^4",
+        "typescript": "^5.9.2"
       }
     },
     "node_modules/@alloc/quick-lru": {
@@ -1224,6 +1224,7 @@
       "version": "19.1.10",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.10.tgz",
       "integrity": "sha512-EhBeSYX0Y6ye8pNebpKrwFJq7BoQ8J5SO6NlvNwwHjSj6adXJViPQrKlsyPw7hLBLvckEMO1yxeGdR82YBBlDg==",
+      "dev": true,
       "dependencies": {
         "csstype": "^3.0.2"
       }
@@ -1232,6 +1233,7 @@
       "version": "19.1.7",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.1.7.tgz",
       "integrity": "sha512-i5ZzwYpqjmrKenzkoLM2Ibzt6mAsM7pxB6BCIouEVVmgiqaMj1TjaK7hnA36hbW5aZv20kx7Lw6hWzPWg0Rurw==",
+      "dev": true,
       "peerDependencies": {
         "@types/react": "^19.0.0"
       }
@@ -2223,7 +2225,8 @@
     "node_modules/csstype": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
-      "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="
+      "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
+      "dev": true
     },
     "node_modules/damerau-levenshtein": {
       "version": "1.0.8",
@@ -5544,6 +5547,7 @@
       "version": "5.9.2",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.2.tgz",
       "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
+      "dev": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/package.json
+++ b/package.json
@@ -9,20 +9,20 @@
     "lint": "eslint"
   },
   "dependencies": {
-    "@types/react-dom": "^19.1.7",
     "lucide-react": "^0.540.0",
     "next": "15.5.0",
     "react": "19.1.0",
-    "react-dom": "19.1.0",
-    "typescript": "^5.9.2"
+    "react-dom": "19.1.0"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3",
     "@tailwindcss/postcss": "^4",
     "@types/node": "^24.3.0",
     "@types/react": "^19.1.10",
+    "@types/react-dom": "^19.1.7",
     "eslint": "^9",
     "eslint-config-next": "15.5.0",
-    "tailwindcss": "^4"
+    "tailwindcss": "^4",
+    "typescript": "^5.9.2"
   }
 }


### PR DESCRIPTION
## Summary
- move `@types/react-dom` and `typescript` to devDependencies
- update lockfile

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a7ba525f388320ae982b534efbf69c